### PR TITLE
👷 Updated scraper to remove the annoying comments

### DIFF
--- a/.github/workflows/scrape.yaml
+++ b/.github/workflows/scrape.yaml
@@ -42,7 +42,7 @@ jobs:
           git config --global user.name "${{ github.actor }}"
       - name: Download local friendly website
         # This version of the command rewrites all links and downloads other resources from the website like images
-        run: httrack --near --quiet -%l "en, *" https://neos.com -O1 "./neos-local" +*.css +*.js -ad.doubleclick.net/* +*.gif +*.jpg +*.jpeg +*.png +*.tif +*.bmp +*.zip +*.tar +*.tgz +*.gz +*.rar +*.z +*.mov +*.mpg +*.mpeg +*.avi +*.asf +*.mp3 +*.mp2 +*.rm +*.wav +*.vob +*.qt +*.vid +*.ac3 +*.wma +*.wmv +*.pdf
+        run: httrack --near --quiet --footer "" -%l "en, *" https://neos.com -O1 "./neos-local" +*.css +*.js -ad.doubleclick.net/* +*.gif +*.jpg +*.jpeg +*.png +*.tif +*.bmp +*.zip +*.tar +*.tgz +*.gz +*.rar +*.z +*.mov +*.mpg +*.mpeg +*.avi +*.asf +*.mp3 +*.mp2 +*.rm +*.wav +*.vob +*.qt +*.vid +*.ac3 +*.wma +*.wmv +*.pdf
       - name: Commit and push
         run:  |
           git pull


### PR DESCRIPTION
After googling for a while I found you can use the --footer option to remove the `<!-- Mirrored from neos.com/ by HTTrack Website Copier/3.x [XR&CO'2014], Sat, 14 May 2022 12:13:37 GMT -->` comments so I've gone ahead and added that. This only affects the local friendly scraper